### PR TITLE
use embeded migemo if there is not cmigemo in $PATH

### DIFF
--- a/autoload/vital/__latest__/Migemo/Interactive.vim
+++ b/autoload/vital/__latest__/Migemo/Interactive.vim
@@ -46,14 +46,14 @@ endfunction
 
 
 function! s:generate_regexp(word)
+	if has("migemo")
+		return s:Migemo.generate_regexp(a:word)
+	endif
 	if !exists("s:cmigemo")
 		call s:_init()
 	endif
 	if a:word ==# ""
 		return ""
-	endif
-	if has("migemo")
-		return s:Migemo.generate_regexp(a:word)
 	endif
 	call s:cmigemo.input(a:word)
 	return matchstr(s:cmigemo.get(), 'PATTERN: \zs.*\ze[\r\n]$')


### PR DESCRIPTION
([incsearch-migemo.vim/pull/1](https://github.com/haya14busa/incsearch-migemo.vim/pull/1) にプルリクしたら、こちらが元とのことなので)

[incsearch-migemo.vim](https://github.com/haya14busa/incsearch-migemo.vim/) を Kaoriya版で使うとエラーで検索できなくなりました
エラーを追ってみると cmigemo.exe が $PATH に無いと、 migemo 組み込みであっても
cmigemo.exe の初期化コードが走ってエラーになるようです
初期化コードが走る前に組み込み migemo が動くように patch を書いてみました。いかがでしょうか？
